### PR TITLE
Update 'dataset_dir' path on text_classification.ipynb

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -171,7 +171,7 @@
         "                                    untar=True, cache_dir='.',\n",
         "                                    cache_subdir='')\n",
         "\n",
-        "dataset_dir = os.path.join(os.path.dirname(dataset), 'aclImdb')"
+        "dataset_dir = os.path.join(os.path.dirname(dataset), 'aclImdb_v1/aclImdb')"
       ]
     },
     {


### PR DESCRIPTION
The path on the 'dataset_dir' initialization was wrong, leading to a "FileNotFoundError" in the next cell.

## Summary by Sourcery

Bug Fixes:
- Fixes a FileNotFoundError in the text classification tutorial by correcting the path to the dataset directory.